### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 npm-debug.log
 Desktop.ini
 Thumbs.db
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "escape-string-regexp": "^1.0.5",
     "event-stream": "^3.1.0",
     "fancy-log": "^1.3.2",
-    "gulp-util": "^3.0.0",
     "plugin-error": "^0.1.2",
     "through2": "^2.0.1",
     "vinyl": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "mocha -R spec src/**/*.spec.js"
   },
   "dependencies": {
+    "ansi-colors": "^1.0.1",
     "escape-string-regexp": "^1.0.5",
     "event-stream": "^3.1.0",
     "fancy-log": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "escape-string-regexp": "^1.0.5",
     "event-stream": "^3.1.0",
+    "fancy-log": "^1.3.2",
     "gulp-util": "^3.0.0",
     "plugin-error": "^0.1.2",
     "through2": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "fancy-log": "^1.3.2",
     "gulp-util": "^3.0.0",
     "plugin-error": "^0.1.2",
-    "through2": "^2.0.1"
+    "through2": "^2.0.1",
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "mocha": "~2.0.1",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
     "test": "mocha -R spec src/**/*.spec.js"
   },
   "dependencies": {
-    "through2": "^2.0.1",
-    "gulp-util": "^3.0.0",
     "escape-string-regexp": "^1.0.5",
-    "event-stream": "^3.1.0"
+    "event-stream": "^3.1.0",
+    "gulp-util": "^3.0.0",
+    "plugin-error": "^0.1.2",
+    "through2": "^2.0.1"
   },
   "devDependencies": {
     "mocha": "~2.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ var through = require('through2');
 var PluginError = require('plugin-error');
 var fancyLog = require('fancy-log');
 var colors = require('ansi-colors');
-var vinyl = require('vinyl');
+var File = require('vinyl');
 var path = require('path');
 var fs = require('fs');
 var escapeStringRegexp = require('escape-string-regexp');
@@ -198,7 +198,7 @@ function extractFilePaths(content, targetPath, opt, tagsRegExp) {
 			try {
 				var fileContent = fs.readFileSync(filePath);
 				files.push({
-					file: new vinyl({
+					file: new File({
 						path: filePath,
 						cwd: __dirname,
 						base: path.resolve(__dirname, 'expected', path.dirname(filePath)),

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,8 @@
 'use strict';
+
+//2018-01-02 sc mod: gulp-util deprecation
+//2018-01-02 sc mod: require plugin-error to replace gutil.PluginError
+
 var through = require('through2');
 var gutil = require('gulp-util');
 var path = require('path');
@@ -7,6 +11,7 @@ var escapeStringRegexp = require('escape-string-regexp');
 var magenta = gutil.colors.magenta;
 var cyan = gutil.colors.cyan;
 var red = gutil.colors.red;
+var PluginError = require('plugin-error');
 
 /**
  * Constants
@@ -244,7 +249,7 @@ function bool(options, prop, defaultVal) {
  * @returns {*}
  */
 function error(message) {
-	return new gutil.PluginError(PLUGIN_NAME, message);
+	return new PluginError(PLUGIN_NAME, message);
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,14 @@
 //2018-01-02 sc mod: require plugin-error to replace gutil.PluginError
 //2018-01-02 sc mod: require fancy-log to replace gutil.log
 //2018-01-02 sc mod: require ansi-colors to replace gutil.colors
+//2018-01-02 sc mod: require vinyl to replace gutil.File
 
 var through = require('through2');
 //var gutil = require('gulp-util');
 var PluginError = require('plugin-error');
 var log = require('fancy-log');
 var colors = require('ansi-colors');
+var vinyl = require('vinyl');
 var path = require('path');
 var fs = require('fs');
 var escapeStringRegexp = require('escape-string-regexp');
@@ -196,7 +198,7 @@ function extractFilePaths(content, targetPath, opt, tagsRegExp) {
 			try {
 				var fileContent = fs.readFileSync(filePath);
 				files.push({
-					file: new gutil.File({
+					file: new vinyl({
 						path: filePath,
 						cwd: __dirname,
 						base: path.resolve(__dirname, 'expected', path.dirname(filePath)),

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 //2018-01-02 sc mod: gulp-util deprecation
 //2018-01-02 sc mod: require plugin-error to replace gutil.PluginError
+//2018-01-02 sc mod: require fancy-log to replace gutil.log
 
 var through = require('through2');
 var gutil = require('gulp-util');
@@ -12,6 +13,7 @@ var magenta = gutil.colors.magenta;
 var cyan = gutil.colors.cyan;
 var red = gutil.colors.red;
 var PluginError = require('plugin-error');
+var log = require('fancy-log');
 
 /**
  * Constants
@@ -256,7 +258,7 @@ function error(message) {
  * @param message
  */
 function log(message) {
-	gutil.log(magenta(PLUGIN_NAME), message);
+	log(magenta(PLUGIN_NAME), message);
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@
 var through = require('through2');
 //var gutil = require('gulp-util');
 var PluginError = require('plugin-error');
-var log = require('fancy-log');
+var fancyLog = require('fancy-log');
 var colors = require('ansi-colors');
 var vinyl = require('vinyl');
 var path = require('path');
@@ -263,7 +263,7 @@ function error(message) {
  * @param message
  */
 function log(message) {
-	log(magenta(PLUGIN_NAME), message);
+	fancyLog(magenta(PLUGIN_NAME), message);
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -3,17 +3,20 @@
 //2018-01-02 sc mod: gulp-util deprecation
 //2018-01-02 sc mod: require plugin-error to replace gutil.PluginError
 //2018-01-02 sc mod: require fancy-log to replace gutil.log
+//2018-01-02 sc mod: require ansi-colors to replace gutil.colors
 
 var through = require('through2');
-var gutil = require('gulp-util');
+//var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
+var log = require('fancy-log');
+var colors = require('ansi-colors');
 var path = require('path');
 var fs = require('fs');
 var escapeStringRegexp = require('escape-string-regexp');
-var magenta = gutil.colors.magenta;
-var cyan = gutil.colors.cyan;
-var red = gutil.colors.red;
-var PluginError = require('plugin-error');
-var log = require('fancy-log');
+var magenta = colors.magenta;
+var cyan = colors.cyan;
+var red = colors.red;
+
 
 /**
  * Constants

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -8,7 +8,7 @@ var fs = require('fs');
 var injectPartials = require('../.');
 //var gutil = require('gulp-util');
 var fancyLog =require('fancy-log');
-var vinyl = require('vinyl');
+var File = require('vinyl');
 var es = require('event-stream');
 var should = require('should');
 var path = require('path');
@@ -128,7 +128,7 @@ function src(files, opt) {
 // get expected file
 function expectedFile(file) {
 	var filepath = path.resolve(__dirname, 'expected', file);
-	return new vinyl({
+	return new File({
 		path: filepath,
 		cwd: __dirname,
 		base: path.resolve(__dirname, 'expected', path.dirname(file)),
@@ -139,7 +139,7 @@ function expectedFile(file) {
 // get fixture
 function fixture(file, read) {
 	var filepath = path.resolve(__dirname, 'fixtures', file);
-	return new vinyl({
+	return new File({
 		path: filepath,
 		cwd: __dirname,
 		base: path.resolve(__dirname, 'fixtures', path.dirname(file)),

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -18,15 +18,15 @@ describe('gulp-inject-partials', function(){
 	var logOutput = [];
 
 	beforeEach(function () {
-		log = fancyLog;
+		log = fancyLog.log;
 		logOutput = [];
-		fancyLog = function () {
+		fancyLog.log = function () {
 			logOutput.push(arguments);
 		};		
 	});
 
 	afterEach(function () {
-		fancyLog = log;
+		fancyLog.log = log;
 	});
 
 	it('should inject single partial', function (done){

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -8,6 +8,7 @@ var fs = require('fs');
 var injectPartials = require('../.');
 //var gutil = require('gulp-util');
 var fancyLog =require('fancy-log');
+var vinyl = require('vinyl');
 var es = require('event-stream');
 var should = require('should');
 var path = require('path');
@@ -127,7 +128,7 @@ function src(files, opt) {
 // get expected file
 function expectedFile(file) {
 	var filepath = path.resolve(__dirname, 'expected', file);
-	return new gutil.File({
+	return new vinyl({
 		path: filepath,
 		cwd: __dirname,
 		base: path.resolve(__dirname, 'expected', path.dirname(file)),
@@ -138,7 +139,7 @@ function expectedFile(file) {
 // get fixture
 function fixture(file, read) {
 	var filepath = path.resolve(__dirname, 'fixtures', file);
-	return new gutil.File({
+	return new vinyl({
 		path: filepath,
 		cwd: __dirname,
 		base: path.resolve(__dirname, 'fixtures', path.dirname(file)),

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,8 +1,13 @@
 'use strict';
 
+//2018-01-02 sc mod: gulp-util deprecation
+//2018-01-02 sc mod: require fancy-log to replace gutil.log
+//2018-01-02 sc mod: require vinyl to replace gutil.File
+
 var fs = require('fs');
 var injectPartials = require('../.');
-var gutil = require('gulp-util');
+//var gutil = require('gulp-util');
+var fancyLog =require('fancy-log');
 var es = require('event-stream');
 var should = require('should');
 var path = require('path');
@@ -12,15 +17,15 @@ describe('gulp-inject-partials', function(){
 	var logOutput = [];
 
 	beforeEach(function () {
-		log = gutil.log;
+		log = fancyLog;
 		logOutput = [];
-		gutil.log = function () {
+		fancyLog = function () {
 			logOutput.push(arguments);
 		};		
 	});
 
 	afterEach(function () {
-		gutil.log = log;
+		fancyLog = log;
 	});
 
 	it('should inject single partial', function (done){


### PR DESCRIPTION
Hi there,

Created a hotfix for the gulp-util deprecation issue
Installed dependecies
* plugin-error as replacement for gutil.PluginError
* fancy-log to replace gutil.log
* ansi-colors to replace gutil.colors
* vinyl to replace gutil.File

files modified are:
.gitignore
--- added package-lock.json that occures when using VS code and SourceTree Git manager
package.json
--- added dependencies
index.js
--- mod code

I hope that my first try is a succes?
my firdst pull-request....lol

kind regards
scorpiocoding - kribo