### PR TITLE
Updated event-stream package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "ansi-colors": "^1.1.0",
     "escape-string-regexp": "^1.0.5",
-    "event-stream": "^3.1.0",
+    "event-stream": "^4.0.1",
     "fancy-log": "^1.3.2",
     "plugin-error": "^0.1.2",
     "through2": "^2.0.1",


### PR DESCRIPTION
A widely used Node.js code library listed in NPM's warehouse of repositories was altered to include crypto-coin-stealing malware. The lib in question is flatmap-stream that is used in the version 3.1.0 of event-stream, a dependency of gulp-inject-partials.

This pull request fixes the problem by updating event-stream package version.

Here there are more information about this security issue: [Crypto-coin-stealing code sneaks into fairly popular NPM lib](https://www.theregister.co.uk/2018/11/26/npm_repo_bitcoin_stealer/).